### PR TITLE
Some cleanup and add support for a simplified az:// URI

### DIFF
--- a/.github/scripts/run_dfs_tests.sh
+++ b/.github/scripts/run_dfs_tests.sh
@@ -43,11 +43,17 @@ check_results_from_examples() {
 run_azure_tests() {
   source $1
   echo "Running TEST_DIR=$TEST"
-  echo "az schema utils test" && tiledb_utils_tests "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.$3/$TEST" && tiledb_utils_tests "azb://$AZURE_CONTAINER_NAME/$TEST?endpoint=$AZURE_STORAGE_ACCOUNT.$3" &&
-    echo "az schema storage test" && $CMAKE_BUILD_DIR/test/test_azure_blob_storage --test-dir "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" &&
-    $CMAKE_BUILD_DIR/test/test_azure_blob_storage --test-dir "azb://$AZURE_CONTAINER_NAME/$TEST?account=$AZURE_STORAGE_ACCOUNT" &&
-    echo "az schema storage buffer test" && $CMAKE_BUILD_DIR/test/test_storage_buffer --test-dir "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" &&
-    echo "az schema examples" && time $GITHUB_WORKSPACE/examples/run_examples.sh "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" &&
+  echo "az schema utils test" &&
+    tiledb_utils_tests "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.$3/$TEST" &&
+    tiledb_utils_tests "azb://$AZURE_CONTAINER_NAME/$TEST?endpoint=$AZURE_STORAGE_ACCOUNT.$3" &&
+    echo "az schema storage test" &&
+    $CMAKE_BUILD_DIR/test/test_azure_blob_storage --test-dir "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" &&
+    $CMAKE_BUILD_DIR/test/test_azure_blob_storage --test-dir "az://$AZURE_CONTAINER_NAME/$TEST" ~[read-write-large] &&
+    $CMAKE_BUILD_DIR/test/test_azure_blob_storage --test-dir "azb://$AZURE_CONTAINER_NAME/$TEST?account=$AZURE_STORAGE_ACCOUNT" ~[read-write-large] &&
+    echo "az schema storage buffer test" &&
+    $CMAKE_BUILD_DIR/test/test_storage_buffer --test-dir "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" &&
+    echo "az schema examples" &&
+    time $GITHUB_WORKSPACE/examples/run_examples.sh "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" &&
     echo "az schema small size storage test" &&
     (TILEDB_MAX_STREAM_SIZE=32 $CMAKE_BUILD_DIR/test/test_azure_blob_storage --test-dir "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" [read-write-small] || echo "az schema small size storage test failed") &&
     echo "Running with $1 DONE" &&

--- a/core/src/misc/uri.cc
+++ b/core/src/misc/uri.cc
@@ -176,6 +176,8 @@ azure_uri::azure_uri(const std::string& uri_s) : uri(uri_s) {
     }
     if (begin != std::string::npos) {
       container_ = this->host().substr(0, begin);
+    } else {
+      container_ = this->host();
     }
   }
 }

--- a/core/src/storage/storage_azure_blob.cc
+++ b/core/src/storage/storage_azure_blob.cc
@@ -67,7 +67,8 @@ using namespace azure::storage_lite;
 static std::string run_command(const std::string& command) {
   std::string output;
   std::array<char, 2048> buffer;
-  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command.data(), "r"), pclose);
+  std::string cmd = command + " 2> /dev/null";
+  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.data(), "r"), pclose);
   if (pipe) {
     while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
       output += buffer.data();

--- a/core/src/storage/storage_azure_blob.cc
+++ b/core/src/storage/storage_azure_blob.cc
@@ -196,6 +196,10 @@ AzureBlob::AzureBlob(const std::string& home) {
     if (az_storage_account_env) azure_account = az_storage_account_env;
   }
 
+  if (azure_account.size() == 0) {
+    throw std::system_error(EINVAL, std::generic_category(), "Azure Blob URI does not seem to have an account specified nor does it have AZURE_ACCOUNT_NAME env set");
+  }
+
   if (path_uri.container().size() == 0) {
     throw std::system_error(EPROTO, std::generic_category(), "Azure Blob URI does not seem to have a container specified");
   }

--- a/core/src/storage/storage_azure_blob.cc
+++ b/core/src/storage/storage_azure_blob.cc
@@ -191,16 +191,17 @@ AzureBlob::AzureBlob(const std::string& home) {
   }
 
   std::string azure_account = path_uri.account();
-  if (azure_account.empty() && path_uri.protocol().compare("azb") == 0) {
+  if (azure_account.empty()) {
     char* az_storage_account_env = getenv("AZURE_STORAGE_ACCOUNT");
     if (az_storage_account_env) azure_account = az_storage_account_env;
   }
 
-  if (azure_account.size() == 0 || path_uri.container().size() == 0) {
-    throw std::system_error(EPROTO, std::generic_category(), "Azure Blob URI does not seem to have either an account or a container");
+  if (path_uri.container().size() == 0) {
+    throw std::system_error(EPROTO, std::generic_category(), "Azure Blob URI does not seem to have a container specified");
   }
 
-  // Algorithm to get azure storage credentials. Try AZURE_STORAGE_ACCOUNT_KEY first, followed by AZURE_STORAGE_SAS_TOKEN and last
+  // See https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-data-operations-cli#set-environment-variables-for-authorization-parameters
+  // Algorithm to get azure storage credentials. Try env AZURE_STORAGE_ACCOUNT_KEY first, followed by AZURE_STORAGE_SAS_TOKEN and last
   // try getting an access token directly from CLI
   std::shared_ptr<storage_credential> cred = nullptr;
   std::string azure_account_key = get_account_key(azure_account);
@@ -304,7 +305,7 @@ std::string AzureBlob::real_dir(const std::string& dir) {
   if (dir.find("://") != std::string::npos) {
     azure_uri path_uri(dir);
     std::string account = path_uri.account();
-    if (account.empty() && path_uri.protocol().compare("azb") == 0) {
+    if (account.empty()) {
       char* az_storage_account_env = getenv("AZURE_STORAGE_ACCOUNT");
       if (az_storage_account_env) account = az_storage_account_env;
     }

--- a/core/src/storage/storage_manager_config.cc
+++ b/core/src/storage/storage_manager_config.cc
@@ -86,6 +86,8 @@ StorageManagerConfig::~StorageManagerConfig() {
 /*             MUTATORS           */
 /* ****************************** */
 
+#define CONCAT_ERRMSG(x, y, z) x+"\n"+y+"\n"+TILEDB_FS_ERRMSG+z
+
 int StorageManagerConfig::init(
     const char* home,
 #ifdef HAVE_MPI
@@ -106,7 +108,7 @@ int StorageManagerConfig::init(
        try {
          fs_ = new AzureBlob(home_);
        } catch(std::system_error& ex) {
-         errmsg = "Azure Storage Blob initialization failed for home=" + home_ + "; " + tiledb_fs_errmsg + "; " + ex.what();
+         errmsg = CONCAT_ERRMSG("Azure Storage Blob initialization failed for home=" + home_, tiledb_fs_errmsg, ex.what());
          PRINT_ERROR(errmsg);
 	 tiledb_smc_errmsg = TILEDB_SMC_ERRMSG + errmsg;
 	 return TILEDB_SMC_ERR;
@@ -115,7 +117,7 @@ int StorageManagerConfig::init(
        try {
           fs_ = new S3(home_);
        } catch(std::system_error& ex) {
-         errmsg = "S3 Storage initialization failed for home=" + home_ + "; " + tiledb_fs_errmsg + "; " + ex.what();
+         errmsg = CONCAT_ERRMSG("S3 Storage initialization failed for home=" + home_, tiledb_fs_errmsg, ex.what());
          PRINT_ERROR(ex.what());
 	 tiledb_smc_errmsg = TILEDB_SMC_ERRMSG + errmsg;
 	 return TILEDB_SMC_ERR;
@@ -124,7 +126,7 @@ int StorageManagerConfig::init(
        try {
           fs_ = new GCS(home_);
        } catch(std::system_error& ex) {
-         errmsg =  "GCS Storage initialization failed for home=" + home_ + "; " + tiledb_fs_errmsg + "; " + ex.what();
+         errmsg =  CONCAT_ERRMSG("GCS Storage initialization failed for home=" + home_, tiledb_fs_errmsg, ex.what());
          PRINT_ERROR(ex.what());
 	 tiledb_smc_errmsg = TILEDB_SMC_ERRMSG + errmsg;
 	 return TILEDB_SMC_ERR;
@@ -137,7 +139,7 @@ int StorageManagerConfig::init(
 	 throw std::system_error(EPROTONOSUPPORT, std::generic_category(), "TileDB built with HDFS support disabled.");
 #endif
        } catch(std::system_error& ex) {
-         errmsg =  "HDFS initialization failed for home=" + home_ + "; " + tiledb_fs_errmsg + "; " + ex.what();
+         errmsg = CONCAT_ERRMSG("HDFS initialization failed for home=" + home_, tiledb_fs_errmsg, ex.what());
 	 PRINT_ERROR(ex.what());
 	 tiledb_smc_errmsg = TILEDB_SMC_ERRMSG + errmsg;
 	 return TILEDB_SMC_ERR;

--- a/core/src/storage/storage_manager_config.cc
+++ b/core/src/storage/storage_manager_config.cc
@@ -109,9 +109,10 @@ int StorageManagerConfig::init(
          fs_ = new AzureBlob(home_);
        } catch(std::system_error& ex) {
          errmsg = CONCAT_ERRMSG("Azure Storage Blob initialization failed for home=" + home_, tiledb_fs_errmsg, ex.what());
+         printf("%s\n", errmsg.c_str());
          PRINT_ERROR(errmsg);
-	 tiledb_smc_errmsg = TILEDB_SMC_ERRMSG + errmsg;
-	 return TILEDB_SMC_ERR;
+         tiledb_smc_errmsg = TILEDB_SMC_ERRMSG + errmsg;
+         return TILEDB_SMC_ERR;
        }
      } else if (is_s3_storage_path(home_)) {
        try {
@@ -119,8 +120,8 @@ int StorageManagerConfig::init(
        } catch(std::system_error& ex) {
          errmsg = CONCAT_ERRMSG("S3 Storage initialization failed for home=" + home_, tiledb_fs_errmsg, ex.what());
          PRINT_ERROR(ex.what());
-	 tiledb_smc_errmsg = TILEDB_SMC_ERRMSG + errmsg;
-	 return TILEDB_SMC_ERR;
+         tiledb_smc_errmsg = TILEDB_SMC_ERRMSG + errmsg;
+         return TILEDB_SMC_ERR;
        }
      } else if (is_gcs_path(home_)) {
        try {
@@ -128,21 +129,21 @@ int StorageManagerConfig::init(
        } catch(std::system_error& ex) {
          errmsg =  CONCAT_ERRMSG("GCS Storage initialization failed for home=" + home_, tiledb_fs_errmsg, ex.what());
          PRINT_ERROR(ex.what());
-	 tiledb_smc_errmsg = TILEDB_SMC_ERRMSG + errmsg;
-	 return TILEDB_SMC_ERR;
+         tiledb_smc_errmsg = TILEDB_SMC_ERRMSG + errmsg;
+         return TILEDB_SMC_ERR;
        }
      } else if (is_supported_cloud_path(home_)) {
        try {
 #ifdef USE_HDFS
-	 fs_ = new HDFS(home_);
+         fs_ = new HDFS(home_);
 #else
-	 throw std::system_error(EPROTONOSUPPORT, std::generic_category(), "TileDB built with HDFS support disabled.");
+         throw std::system_error(EPROTONOSUPPORT, std::generic_category(), "TileDB built with HDFS support disabled.");
 #endif
        } catch(std::system_error& ex) {
          errmsg = CONCAT_ERRMSG("HDFS initialization failed for home=" + home_, tiledb_fs_errmsg, ex.what());
-	 PRINT_ERROR(ex.what());
-	 tiledb_smc_errmsg = TILEDB_SMC_ERRMSG + errmsg;
-	 return TILEDB_SMC_ERR;
+         PRINT_ERROR(ex.what());
+         tiledb_smc_errmsg = TILEDB_SMC_ERRMSG + errmsg;
+         return TILEDB_SMC_ERR;
        }
      } else {
        tiledb_smc_errmsg = "No TileDB support for home=" + home_;

--- a/test/src/storage_manager/test_azure_blob_storage.cc
+++ b/test/src/storage_manager/test_azure_blob_storage.cc
@@ -73,18 +73,17 @@ class AzureBlobTestFixture {
 
 TEST_CASE("Test AzureBlob constructor", "[constr]") {
   CHECK_THROWS(new AzureBlob("wasbs://my_container/path"));
+  CHECK_THROWS(new AzureBlob("az:///path"));
   CHECK_THROWS(new AzureBlob("az://my_container@my_account.blob.core.windows.net/path"));
   CHECK_THROWS(new AzureBlob("az://my_container@blob.core.windows.net/path"));
   char *key = getenv("AZURE_STORAGE_KEY");
   if (key) {
     key = strdup(key);
     unsetenv("AZURE_STORAGE_KEY");
-  }
-  std::string sas_token = "AZURE_STORAGE_SAS_TOKEN=non-existent-token";
-  CHECK(putenv(const_cast<char *>(sas_token.c_str())) == 0);
-  CHECK_THROWS(new AzureBlob("az://my_container@my_account.blob.core.windows.net/path"));
-  unsetenv("AZURE_STORAGE_SAS_TOKEN");
-  if (key) {
+    std::string sas_token = "AZURE_STORAGE_SAS_TOKEN=non-existent-token";
+    CHECK(putenv(const_cast<char *>(sas_token.c_str())) == 0);
+    CHECK_THROWS(new AzureBlob("az://my_container@my_account.blob.core.windows.net/path"));
+    unsetenv("AZURE_STORAGE_SAS_TOKEN");
     setenv("AZURE_STORAGE_KEY", key, true);
     free(key);
   }

--- a/test/src/storage_manager/test_azure_blob_storage.cc
+++ b/test/src/storage_manager/test_azure_blob_storage.cc
@@ -75,13 +75,19 @@ TEST_CASE("Test AzureBlob constructor", "[constr]") {
   CHECK_THROWS(new AzureBlob("wasbs://my_container/path"));
   CHECK_THROWS(new AzureBlob("az://my_container@my_account.blob.core.windows.net/path"));
   CHECK_THROWS(new AzureBlob("az://my_container@blob.core.windows.net/path"));
-  //  CHECK_THROWS(new AzureBlob("az://non-existent-container@blob.core.windows.met/path"));
-  if (getenv("AZURE_STORAGE_ACCOUNT")) {
-      unsetenv( "AZURE_STORAGE_ACCOUNT");
+  char *key = getenv("AZURE_STORAGE_KEY");
+  if (key) {
+    key = strdup(key);
+    unsetenv("AZURE_STORAGE_KEY");
   }
   std::string sas_token = "AZURE_STORAGE_SAS_TOKEN=non-existent-token";
   CHECK(putenv(const_cast<char *>(sas_token.c_str())) == 0);
-  // CHECK_THROWS(new AzureBlob("az://my_container@my_account.blob.core.windows.net/path"));
+  CHECK_THROWS(new AzureBlob("az://my_container@my_account.blob.core.windows.net/path"));
+  unsetenv("AZURE_STORAGE_SAS_TOKEN");
+  if (key) {
+    setenv("AZURE_STORAGE_KEY", key, true);
+    free(key);
+  }
 }
 
 TEST_CASE_METHOD(AzureBlobTestFixture, "Test AzureBlob cwd", "[cwd]") {
@@ -101,8 +107,8 @@ TEST_CASE_METHOD(AzureBlobTestFixture, "Test AzureBlob real_dir", "[real-dir]") 
     return;
   }
   CHECK(azure_blob->real_dir("").compare(azure_blob->current_dir()) == 0);
-  CHECK(azure_blob->real_dir("xxx").compare(azure_blob->current_dir()+"/xxx") == 0);
-  CHECK(azure_blob->real_dir("xxx/yyy").compare(azure_blob->current_dir()+"/xxx/yyy") == 0);
+  CHECK(azure_blob->real_dir("xxx").compare(TileDBUtils::append_path(azure_blob->current_dir(),"xxx")) == 0);
+  CHECK(azure_blob->real_dir("xxx/yyy").compare(TileDBUtils::append_path(azure_blob->current_dir(), "xxx/yyy")) == 0);
   CHECK(azure_blob->real_dir("/xxx/yyy").compare("xxx/yyy") == 0);
   azure_uri test_uri(get_test_dir());
   CHECK(azure_blob->real_dir(get_test_dir()).compare(test_uri.path().substr(1)) == 0);
@@ -283,7 +289,7 @@ TEST_CASE_METHOD(AzureBlobTestFixture, "Test AzureBlob parallel operations", "[p
 
   bool complete = true;
   uint iterations = 2;
-  size_t size = 10*1024*1024;
+  size_t size = 10*1024;
 
   #pragma omp parallel for
   for (uint i=0; i<iterations; i++) {


### PR DESCRIPTION
The cleanup is to mainly aid the gatk logging of issues w.r.t to errors in the Cloud Storage systems.

Also add support for a simplified `az` URI of the type `az://<container>/<path>` especially if the env contains `AZURE_ACCOUNT_NAME` and the endpoint is the default `blob.core.windows.net`. This is in addition to `az://<container>@<account_name>.<endpoint>/<path>`. Makes the `az` and `azb` URIs identical if the account information is in env and/or the endpoint is the default.