### PR TITLE
Support caching of bookkeeping files locally for cloud workspaces/arrays

### DIFF
--- a/.github/scripts/install_supported_codec.sh
+++ b/.github/scripts/install_supported_codec.sh
@@ -7,15 +7,15 @@ sudo apt-get install -y zstd &&
 export ENABLE_ZSTD=1
 
 # Install Blosc
-#echo "Installing Blosc..."
-#pushd `pwd`
-#git clone https://github.com/Blosc/c-blosc.git &&
-#	cd c-blosc &&
-#	mkdir build &&
-#	cd build &&
-#	cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR .. &&
-#	cmake --build . &&
-#	sudo cmake --build . --target install &&
-#	export ENABLE_BLOSC=1
-#popd
-#echo "Installing Blosc DONE"
+echo "Installing Blosc..."
+pushd `pwd`
+git clone https://github.com/Blosc/c-blosc.git &&
+	cd c-blosc &&
+	mkdir build &&
+	cd build &&
+	cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR .. &&
+	cmake --build . &&
+	sudo cmake --build . --target install &&
+	export ENABLE_BLOSC=1
+popd
+echo "Installing Blosc DONE"

--- a/.github/scripts/install_supported_codec.sh
+++ b/.github/scripts/install_supported_codec.sh
@@ -7,15 +7,15 @@ sudo apt-get install -y zstd &&
 export ENABLE_ZSTD=1
 
 # Install Blosc
-echo "Installing Blosc..."
-pushd `pwd`
-git clone https://github.com/Blosc/c-blosc.git &&
-	cd c-blosc &&
-	mkdir build &&
-	cd build &&
-	cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR .. &&
-	cmake --build . &&
-	sudo cmake --build . --target install &&
-	export ENABLE_BLOSC=1
-popd
-echo "Installing Blosc DONE"
+#echo "Installing Blosc..."
+#pushd `pwd`
+#git clone https://github.com/Blosc/c-blosc.git &&
+#	cd c-blosc &&
+#	mkdir build &&
+#	cd build &&
+#	cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR .. &&
+#	cmake --build . &&
+#	sudo cmake --build . --target install &&
+#	export ENABLE_BLOSC=1
+#popd
+#echo "Installing Blosc DONE"

--- a/.github/scripts/run_dfs_tests.sh
+++ b/.github/scripts/run_dfs_tests.sh
@@ -53,7 +53,7 @@ run_azure_tests() {
     echo "az schema storage buffer test" &&
     $CMAKE_BUILD_DIR/test/test_storage_buffer --test-dir "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" &&
     echo "az schema examples" &&
-    time $GITHUB_WORKSPACE/examples/run_examples.sh "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" &&
+    TILEDB_CACHE=1 time $GITHUB_WORKSPACE/examples/run_examples.sh "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" &&
     echo "az schema small size storage test" &&
     (TILEDB_MAX_STREAM_SIZE=32 $CMAKE_BUILD_DIR/test/test_azure_blob_storage --test-dir "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" [read-write-small] || echo "az schema small size storage test failed") &&
     echo "Running with $1 DONE" &&

--- a/.github/scripts/run_dfs_tests.sh
+++ b/.github/scripts/run_dfs_tests.sh
@@ -119,7 +119,8 @@ elif [[ $INSTALL_TYPE == azurite ]]; then
   $CMAKE_BUILD_DIR/test/test_storage_buffer --test-dir "az://test@devstoreaccount1.blob/$TEST" &&
   AZURE_STORAGE_ACCOUNT=$TEMP_VAR
   $GITHUB_WORKSPACE/examples/run_examples.sh "az://test@devstoreaccount1.blob/$TEST" &&
-  $GITHUB_WORKSPACE/examples/run_examples.sh "azb://test/$TEST?account=devstoreaccount1"
+  $GITHUB_WORKSPACE/examples/run_examples.sh "azb://test/$TEST?account=devstoreaccount1" &&
+  TILEDB_CACHE=1 $GITHUB_WORKSPACE/examples/run_examples.sh "az://test/$TEST?account=devstoreaccount1"
 
 elif [[ $INSTALL_TYPE == aws ]]; then
   TILEDB_BENCHMARK=1

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -193,7 +193,6 @@ jobs:
         AWS_TAR: ${{secrets.AWS_TAR}}
 
     - name: Upload Report to CodeCov
-      if: startsWith(matrix.os,'ubuntu')
-      uses: codecov/codecov-action@v3
-      with:
-        gcov: true
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -159,7 +159,7 @@ jobs:
         make -j4
         make tests -j 4
         export TILEDB_BENCHMARK=1
-        time test/test_sparse_array_benchmark
+        time TILEDB_BOOKKEEPING_STATS=1 TILEDB_CACHE=1 test/test_sparse_array_benchmark
         export TILEDB_DISABLE_FILE_LOCKING=1
         time test/test_sparse_array_benchmark
         export TILEDB_KEEP_FILE_HANDLES_OPEN=1

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -51,24 +51,19 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         # All supported types
-        type: [basic, basic-no-hdfs, basic-codec, hdfs, gcs, azure, azurite, aws]
+        # type: [basic, basic-no-hdfs, basic-codec, hdfs, gcs, azure, azurite, aws]
+        type: [basic, basic-no-hdfs, basic-codec, hdfs, gcs, azure, aws]
         include:
-          - os: macos-11
+          - os: macos-13
             type: basic
             openssl-version: 1.1
-          - os: macos-11
-            type: basic
-            openssl-version: 3
-          - os: macos-12
-            type: basic
-            openssl-version: 1.1
-          - os: macos-12
+          - os: macos-13
             type: basic
             openssl-version: 3
           - os: ubuntu-22.04
             type: basic
-          - os: ubuntu-22.04
-            type: azurite
+            #- os: ubuntu-22.04
+            #type: azurite
           - os: ubuntu-22.04
             type: aws
           - os: ubuntu-22.04
@@ -79,7 +74,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Create Build Environment
       shell: bash
@@ -90,27 +85,27 @@ jobs:
         mkdir -p /usr/local/share/vcpkg/ports
 
     - name: Cache AWS SDK
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/awssdk-install
         key: awssdk-${{env.AWSSDK_VER}}-${{matrix.os}}-openssl-${{matrix.openssl-version}}-v1
 
     - name: Cache GCS SDK
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/gcssdk-install
         key: gcssdk-${{env.GCSSDK_VER}}-${{matrix.os}}-openssl-${{matrix.openssl-version}}-v1
 
     - name: Cache Catch2 artifacts
       if: startsWith(matrix.os,'ubuntu')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/catch2-install
         key: catch2-${{env.CATCH2_VER}}-v0-${{matrix.os}}
         
     - name: Cache Distributed FileSystems
       if: matrix.type == 'hdfs' || matrix.type == 'gcs'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{runner.workspace}}/hadoop-${{env.HADOOP_VER}}
         key: dfs-${{env.HADOOP_VER}}-v1-${{matrix.os}}-openssl-v1
@@ -198,6 +193,7 @@ jobs:
         AWS_TAR: ${{secrets.AWS_TAR}}
 
     - name: Upload Report to CodeCov
+      if: startsWith(matrix.os,'ubuntu')
       uses: codecov/codecov-action@v3
       with:
         gcov: true

--- a/core/EnvironmentVariables.md
+++ b/core/EnvironmentVariables.md
@@ -15,3 +15,10 @@ The use of these Environment Variables will alter the behavior of TileDB. These 
 
 * TILEDB_MAX_STREAM_SIZE
      For azure blob storage, use download_blob_to_stream to read lengths < TILEDB_MAX_STREAM_SIZE. If this is not set, the default is 1024 bytes defined in core/include/storage_manager/storage_azure_blob.h.
+
+
+* TILEDB_CACHE
+    Cache bookkeeping and other files as necessary
+
+* TILEDB_BOOKKEEPING_STATS
+    Print memory and time statistics for reading and loading bookkeeping files

--- a/core/include/c_api/tiledb_utils.h
+++ b/core/include/c_api/tiledb_utils.h
@@ -7,7 +7,7 @@
  *
  * @copyright Copyright (c) 2018 Omics Data Automation Inc. and Intel Corporation
  * @copyright Copyright (c) 2020-2021 Omics Data Automation Inc.
- * @copyright Copyright (c) 2023 dātma, inc™
+ * @copyright Copyright (c) 2023-2024 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -60,6 +60,8 @@ bool array_exists(const std::string& workspace, const std::string& array_name);
 std::vector<std::string> get_array_names(const std::string& workspace);
 
 std::vector<std::string> get_fragment_names(const std::string& workspace);
+
+int cache_fragment_metadata(const std::string& workspace, const std::string& array_name);
 
 bool is_dir(const std::string& dirpath);
 

--- a/core/include/misc/mem_utils.h
+++ b/core/include/misc/mem_utils.h
@@ -7,6 +7,7 @@
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  * @copyright Copyright (c) 2021 Omics Data Automation Inc.
+ * @copyright Copyright (c) 2024 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/include/misc/mem_utils.h
+++ b/core/include/misc/mem_utils.h
@@ -33,6 +33,8 @@
 
 #pragma once
 
+void print_rusage(const std::string& msg);
+
 void print_memory_stats(const std::string& msg);
 
 void trim_memory();

--- a/core/include/misc/utils.h
+++ b/core/include/misc/utils.h
@@ -7,6 +7,7 @@
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  * @copyright Copyright (c) 2021 Omics Data Automation Inc.
+ * @copyright Copyright (c) 2024 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -245,6 +246,19 @@ bool is_hdfs_path(const std::string& pathURL);
  * @return true if enviroment variable exists and is set to true or "1"
  */
 bool is_env_set(const std::string& name);
+
+/**
+ * Given a path, retrieve the last segment(filename)
+ * @param path to file
+ * @return last segment of path
+ */
+std::string get_filename_from_path(const std::string& path);
+
+/**
+ * Get the book-keeping cache, used with cloud paths generally
+ * @return the path to the book-keeping cache
+ */
+std::string get_fragment_metadata_cache_dir();
 
 /**
  * Creates a new directory.

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -470,6 +470,7 @@ int move_across_filesystems(const std::string& src, const std::string& dest)
   rc = write_file(tiledb_ctx, dest, buffer, size);
   rc |= close_file(tiledb_ctx, dest);
   finalize(tiledb_ctx);
+  free(buffer);
   return rc;
 }
 

--- a/core/src/fragment/book_keeping.cc
+++ b/core/src/fragment/book_keeping.cc
@@ -405,7 +405,7 @@ int BookKeeping::load(StorageFS *fs) {
     auto cache = StorageFS::slashify(std::filesystem::temp_directory_path()) + "tiledb_bookkeeping/";
     std::string filename = cache + get_filename_from_path(fragment_name_);
     if (!posix_fs.is_file(filename)) {
-      std::cout << "Caching Bookkeeping file=" << filename << std::endl;
+      std::cerr << "*** Bookkeeping file for fragment=" << fragment_name_ << " cached at path=" << filename << std::endl;
       if (!posix_fs.is_dir(cache)) {
         if (posix_fs.create_dir(cache)) {
           BK_ERROR_WITH_PATH("Could not create directory in temp_directory_path", cache);

--- a/core/src/fragment/book_keeping.cc
+++ b/core/src/fragment/book_keeping.cc
@@ -360,11 +360,9 @@ int unlock_file(int fd) {
 
 std::string get_filename_from_path(const std::string& path) {
   size_t pos = path.find_last_of("\\/");
-  if (pos == std::string::npos) {
+  if (pos == std::string::npos || path.length() == pos++) {
     return path;
   } else {
-    pos++;
-    assert(pos < path.size());
     return path.substr(pos);
   }
 }

--- a/core/src/fragment/book_keeping.cc
+++ b/core/src/fragment/book_keeping.cc
@@ -7,6 +7,7 @@
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  * @copyright Copyright (c) 2021-2022 Omics Data Automation Inc.
+ * @copyright Copyright (c) 2024 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,20 +41,15 @@
 #include <cassert>
 #include <cstring>
 #include <fcntl.h>
-#include <filesystem>
-#include <functional>
 #include <iostream>
-#include <sys/file.h>
+
 
 
 /* ****************************** */
 /*             MACROS             */
 /* ****************************** */
 
-#define BK_ERROR(MSG) TILEDB_ERROR(TILEDB_BK_ERRMSG, MSG, tiledb_bk_errmsg)
-#define BK_ERROR_WITH_PATH(MSG, PATH) SYSTEM_ERROR(TILEDB_BK_ERRMSG, MSG, PATH, tiledb_bk_errmsg)
-#define BK_ERROR_FREE_BUFFER(MSG, PATH) free(buffer); SYSTEM_ERROR(TILEDB_BK_ERRMSG, MSG, PATH, tiledb_bk_errmsg)
-
+#define BK_ERROR(MSG) delete buffer_; buffer_ = 0; TILEDB_ERROR(TILEDB_BK_ERRMSG, MSG, tiledb_bk_errmsg)
 
 
 /* ****************************** */
@@ -343,30 +339,6 @@ int BookKeeping::init(const void* non_empty_domain) {
   return TILEDB_BK_OK;
 }
 
-int lock_file(const std::string& filename) {
-  int fd;
-  fd = open(filename.c_str(), O_WRONLY | O_CREAT | O_CLOEXEC | O_SYNC, S_IRWXU);
-  if (fd > 0 && flock(fd, LOCK_EX)) {
-    BK_ERROR_WITH_PATH("Could not lock file", filename);
-    return TILEDB_BK_ERR;
-  }
-  return fd;
-}
-
-int unlock_file(int fd) {
-  flock(fd, LOCK_UN);
-  return close(fd);
-}
-
-std::string get_filename_from_path(const std::string& path) {
-  size_t pos = path.find_last_of("\\/");
-  if (pos == std::string::npos || path.length() == pos++) {
-    return path;
-  } else {
-    return path.substr(pos);
-  }
-}
-
 /* FORMAT:
  * non_empty_domain_size(size_t) non_empty_domain(void*)  
  * mbr_num(int64_t)
@@ -397,53 +369,18 @@ int BookKeeping::load(StorageFS *fs) {
   if (is_env_set("TILEDB_BOOKKEEPING_STATS")) {
     print_memory_stats("Before BookKeeping::load");
   }
+  // Cache the booking file in tmpdir for cloud paths
+  bool used_cache = false;
   PosixFS posix_fs;
-  // Hash and cache the booking file in tmpdir for cloud paths
   if (dynamic_cast<const StorageCloudFS *>(fs) != nullptr && is_env_set("TILEDB_CACHE")) {
-    auto cache = StorageFS::slashify(std::filesystem::temp_directory_path()) + "tiledb_bookkeeping/";
-    std::string filename = cache + get_filename_from_path(fragment_name_);
-    if (!posix_fs.is_file(filename)) {
-      std::cerr << "*** Bookkeeping file for fragment=" << fragment_name_ << " cached at path=" << filename << std::endl;
-      if (!posix_fs.is_dir(cache)) {
-        if (posix_fs.create_dir(cache)) {
-          BK_ERROR_WITH_PATH("Could not create directory in temp_directory_path", cache);
-          return TILEDB_BK_ERR;
-        }
-      }
-      int fd = lock_file(filename);
-      if (fd > 0) {
-        auto chunk = TILEDB_UT_MAX_WRITE_COUNT;
-        auto buffer = malloc(chunk);
-        auto size = fs->file_size(filename_);
-        if (size == TILEDB_FS_ERR) {
-          BK_ERROR_FREE_BUFFER("Could not get filesize", filename_);
-          return TILEDB_BK_ERR;
-        }
-        auto remaining = size;
-        size_t nbytes;
-        while (remaining > 0) {
-          nbytes = remaining<chunk?remaining:chunk;
-          if (fs->read_from_file(filename_, size-remaining, buffer, nbytes)) {
-            BK_ERROR_FREE_BUFFER("Could not read from file", filename_);
-            return TILEDB_BK_ERR;
-          }
-	  auto written = write(fd, buffer, nbytes);
-          if (written == -1 || (size_t)written != nbytes) {
-            BK_ERROR_FREE_BUFFER("Could not write to file", filename);
-            return TILEDB_BK_ERR;
-          }
-          remaining-=nbytes;
-        }
-        free(buffer);
-        unlock_file(fd);
-        assert(posix_fs.file_size(filename) == size);
-      }
+    std::string cached_filename = get_fragment_metadata_cache_dir() + get_filename_from_path(fragment_name_);
+    if (posix_fs.is_file(cached_filename)) {
+      buffer_ = new CompressedStorageBuffer(&posix_fs, cached_filename, download_compressed_size_, /*is_read*/ true,
+                                            TILEDB_GZIP, TILEDB_COMPRESSION_LEVEL_GZIP);
+      used_cache = true;
     }
-    filename_ = filename;
-    // Create StorageBuffer to deserialize book_keeping content
-    buffer_ = new CompressedStorageBuffer(&posix_fs, filename_, download_compressed_size_, /*is_read*/ true,
-                                          TILEDB_GZIP, TILEDB_COMPRESSION_LEVEL_GZIP);
-  } else {
+  }
+  if (!used_cache) {
     // Create StorageBuffer to deserialize book_keeping content
     buffer_ = new CompressedStorageBuffer(fs, filename_, download_compressed_size_, /*is_read*/ true,
                                           TILEDB_GZIP, TILEDB_COMPRESSION_LEVEL_GZIP);

--- a/core/src/misc/mem_utils.cc
+++ b/core/src/misc/mem_utils.cc
@@ -6,6 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2022 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2024 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/misc/mem_utils.cc
+++ b/core/src/misc/mem_utils.cc
@@ -37,6 +37,9 @@
 #include <string>
 #include <vector>
 
+#include <sys/time.h>
+#include <sys/resource.h>
+
 #ifdef __linux
 #include <malloc.h>
 #endif
@@ -48,7 +51,7 @@ typedef struct statm_t{
 void print_time() {
   time_t track_time = time(NULL);
   tm* current = localtime(&track_time);
-  char buffer[32];
+  char buffer[40];
   // Format %c(locale dependent) e.g. Fri Mar 18 16:13:48 2022 for EN_US
   std::strftime(buffer, sizeof(buffer), "%c ", current);
   std::cerr << buffer;
@@ -68,6 +71,21 @@ std::string readable_size(size_t size) {
     }
   }
   return std::to_string(size);
+}
+
+void print_rusage(const std::string& msg) {
+  rusage usage;
+  int result = getrusage(RUSAGE_SELF, &usage);
+  std::cerr << msg << std::endl;
+  if (result == 0) {
+    std::cerr << "\tuser cpu time=" << usage.ru_utime.tv_sec << "seconds " << usage.ru_utime.tv_usec << "microseconds" << std::endl;
+    std::cerr << "\tsys cpu time=" << usage.ru_stime.tv_sec << "seconds " << usage.ru_stime.tv_usec << "microseconds" << std::endl;
+#ifdef __linux
+    std::cerr << "\tmaximum resident set size: " << usage.ru_maxrss << "KB" << std::endl;
+#else
+    std::cerr << "\tmaximum resident set size: " << usage.ru_maxrss << "B" << std::endl;
+#endif
+  }
 }
     
 void print_memory_stats(const std::string& msg) {
@@ -95,7 +113,7 @@ void print_memory_stats(const std::string& msg) {
             << " data=" << readable_size(result.data) << " dt=" << readable_size(result.dt) << std::endl;
 #else
   print_time();
-  std::cerr << "TBD: Memory stats " << msg << std::endl;
+  print_rusage(msg);
 #endif
 }
 

--- a/core/src/misc/utils.cc
+++ b/core/src/misc/utils.cc
@@ -7,7 +7,7 @@
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  * @copyright Copyright (c) 2018-2019, 2021 Omics Data Automation, Inc.
- * @copyright Copyright (c) 2023 dātma, inc™
+ * @copyright Copyright (c) 2023-2024 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,6 +42,7 @@
 #include <cstdio>
 #include <dirent.h>
 #include <fcntl.h>
+#include <filesystem>
 #include <iostream>
 #include <netdb.h>
 #include <set>
@@ -283,6 +284,19 @@ bool is_env_set(const std::string& name) {
   } else {
     return false;
   }
+}
+
+std::string get_filename_from_path(const std::string& path) {
+  size_t pos = path.find_last_of("\\/");
+  if (pos == std::string::npos || path.length() == pos++) {
+    return path;
+  } else {
+    return path.substr(pos);
+  }
+}
+
+std::string get_fragment_metadata_cache_dir() {
+  return StorageFS::slashify(std::filesystem::temp_directory_path()) + "tiledb_bookkeeping/";
 }
 
 int create_dir(StorageFS *fs, const std::string& dir) {

--- a/core/src/storage/storage_buffer.cc
+++ b/core/src/storage/storage_buffer.cc
@@ -6,6 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2020-2022 Omics Data Automation Inc.
+ * @copyright Copyright (c) 2024 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/storage/storage_buffer.cc
+++ b/core/src/storage/storage_buffer.cc
@@ -181,9 +181,9 @@ int StorageBuffer::finalize() {
     rc =  write_buffer();
   }
   rc = fs_->close_file(filename_) || rc;
+  free_buffer();
   if (rc) {
     // error is logged in write_buffer or close_file
-    free_buffer();
     return TILEDB_BF_ERR;
   } else {
     return TILEDB_BF_OK;

--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -7,6 +7,7 @@
 #
 # Copyright (c) 2018 Omics Data Automation Inc. and Intel Corporation
 # Copyright (c) 2019 Omics Data Automation Inc.
+# Copyright (c) 2024 dātma, inc™
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -96,7 +97,9 @@ sleep 5
 run_example ./tiledb_array_read_dense_1 $1 18
 run_example ./tiledb_array_write_sparse_1 $1 19
 sleep 5
+export TILEDB_CACHE=1
 run_example ./tiledb_array_read_sparse_1 $1 20
+unset TILEDB_CACHE
 run_example ./tiledb_array_read_sparse_filter_1 $1 21
 run_example ./tiledb_array_iterator_sparse $1 22
 run_example ./tiledb_array_iterator_sparse_filter $1 23

--- a/examples/src/tiledb_array_read_sparse_1.cc
+++ b/examples/src/tiledb_array_read_sparse_1.cc
@@ -6,6 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2024 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,8 +32,11 @@
  */
 
 #include "tiledb.h"
+#include "tiledb_utils.h"
 #include <cstdio>
 #include <inttypes.h>
+
+bool is_env_set(const std::string& name);
 
 int main(int argc, char *argv[]) {
   // Initialize context with home dir if specified in command line, else
@@ -42,6 +46,11 @@ int main(int argc, char *argv[]) {
     TileDB_Config tiledb_config;
     tiledb_config.home_ = argv[1];
     tiledb_ctx_init(&tiledb_ctx, &tiledb_config);
+    std::string base_dir(argv[1]);
+    if (base_dir.back() != '/') base_dir += '/';
+    if (std::string(base_dir).find("://") != std::string::npos && is_env_set("TILEDB_CACHE")) {
+      TileDBUtils::cache_fragment_metadata(base_dir+"my_workspace", "sparse_arrays/my_array_B");
+    }
   } else {
     tiledb_ctx_init(&tiledb_ctx, NULL);
   }

--- a/test/include/catch2/catch.h
+++ b/test/include/catch2/catch.h
@@ -62,8 +62,10 @@ using namespace Catch::clara;
 #endif
 
 #include "tiledb_utils.h"
+#include "utils.h"
 
 #include "regex"
+#include <filesystem>
 
 #define CHECK_RC(rc, expected) CHECK(rc == expected)
 
@@ -78,6 +80,10 @@ class TempDir {
 
   ~TempDir() {
     TileDBUtils::delete_dir(get_temp_dir());
+    // Beware the following will delete the entire book_keeping cache after running tests
+    if (is_env_set("TILEDB_CACHE")) {
+      TileDBUtils::delete_dir(StorageFS::slashify(std::filesystem::temp_directory_path()) + "tiledb_bookkeeping");
+    }
 
     if (!delete_test_dir_in_destructor_.empty()) {
       TileDBUtils::delete_dir(delete_test_dir_in_destructor_);

--- a/test/src/misc/test_mem_utils.cc
+++ b/test/src/misc/test_mem_utils.cc
@@ -6,6 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2022 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2024 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/src/misc/test_mem_utils.cc
+++ b/test/src/misc/test_mem_utils.cc
@@ -37,4 +37,5 @@ TEST_CASE("Test mem_utils", "[mem_utils]") {
   print_memory_stats("Tracking memory usage START");
   sleep(1);
   print_memory_stats("Tracking memory usage END");
+  print_rusage("Test rusage");
 }


### PR DESCRIPTION
Introduced two env variables - `TILEDB_CACHE` and `TILEDB_BOOKKEEPING_STATS`. For cloud based workspaces, we now allow for the bookkeeping file in a fragment to be cached locally to `tmp` if `TILEDB_CACHE` is set. We also output book keeping memory stats if `TILEDB_BOOKKEEPING_STATS` is set. As soon as we are satisfied with the performance, I envision guarding this with the `DO_MEMORY_PROFILING` C++ macro instead of an environment variable.