### PR TITLE
Refactor and expose cache_fragment_metadata() as api

### DIFF
--- a/core/include/c_api/tiledb_utils.h
+++ b/core/include/c_api/tiledb_utils.h
@@ -61,6 +61,8 @@ std::vector<std::string> get_array_names(const std::string& workspace);
 
 std::vector<std::string> get_fragment_names(const std::string& workspace);
 
+int cache_fragment_metadata(const std::string& workspace, const std::string& array_name);
+
 bool is_dir(const std::string& dirpath);
 
 std::string real_dir(const std::string& dirpath);

--- a/core/include/misc/utils.h
+++ b/core/include/misc/utils.h
@@ -247,6 +247,19 @@ bool is_hdfs_path(const std::string& pathURL);
 bool is_env_set(const std::string& name);
 
 /**
+ * Given a path, retrieve the last segment(filename)
+ * @param path to file
+ * @return last segment of path
+ */
+std::string get_filename_from_path(const std::string& path);
+
+/**
+ * Get the book-keeping cache, used with cloud paths generally
+ * @return the path to the book-keeping cache
+ */
+std::string get_fragment_metadata_cache_dir();
+
+/**
  * Creates a new directory.
  *
  * @param fs The storage filesystem type in use. e.g. posix, hdfs, etc.

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -47,6 +47,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/file.h>
 #include <trace.h>
 
 namespace TileDBUtils {

--- a/core/src/fragment/book_keeping.cc
+++ b/core/src/fragment/book_keeping.cc
@@ -364,7 +364,6 @@ int BookKeeping::init(const void* non_empty_domain) {
  *     tile_var_sizes_attr#<attribute_num-1>_#2 (size_t) ...
  * last_tile_cell_num(int64_t)
  */
-#define RETURN_BK_ERROR do { delete buffer_; buffer_ = 0; return TILEDB_BK_ERR; } while(false)
 int BookKeeping::load(StorageFS *fs) {
   if (is_env_set("TILEDB_BOOKKEEPING_STATS")) {
     print_memory_stats("Before BookKeeping::load");
@@ -388,31 +387,31 @@ int BookKeeping::load(StorageFS *fs) {
   
   // Load non-empty domain
   if(load_non_empty_domain() != TILEDB_BK_OK)
-    RETURN_BK_ERROR;
+    return TILEDB_BK_ERR;
 
   // Load MBRs
   if(load_mbrs() != TILEDB_BK_OK)
-    RETURN_BK_ERROR;
+    return TILEDB_BK_ERR;
 
   // Load bounding coordinates
   if(load_bounding_coords() != TILEDB_BK_OK)
-    RETURN_BK_ERROR;
+    return TILEDB_BK_ERR;
 
   // Load tile offsets
   if(load_tile_offsets() != TILEDB_BK_OK)
-    RETURN_BK_ERROR;
+    return TILEDB_BK_ERR;
 
   // Load variable tile offsets
   if(load_tile_var_offsets() != TILEDB_BK_OK)
-    RETURN_BK_ERROR;
+    return TILEDB_BK_ERR;
 
   // Load variable tile sizes
   if(load_tile_var_sizes() != TILEDB_BK_OK)
-    RETURN_BK_ERROR;
+    return TILEDB_BK_ERR;
 
   // Load cell number of last tile
   if(load_last_tile_cell_num() != TILEDB_BK_OK)
-    RETURN_BK_ERROR;
+    return TILEDB_BK_ERR;
 
   // Free up StorageBuffer
   buffer_->finalize();

--- a/core/src/misc/utils.cc
+++ b/core/src/misc/utils.cc
@@ -42,6 +42,7 @@
 #include <cstdio>
 #include <dirent.h>
 #include <fcntl.h>
+#include <filesystem>
 #include <iostream>
 #include <netdb.h>
 #include <set>
@@ -283,6 +284,19 @@ bool is_env_set(const std::string& name) {
   } else {
     return false;
   }
+}
+
+std::string get_filename_from_path(const std::string& path) {
+  size_t pos = path.find_last_of("\\/");
+  if (pos == std::string::npos || path.length() == pos++) {
+    return path;
+  } else {
+    return path.substr(pos);
+  }
+}
+
+std::string get_fragment_metadata_cache_dir() {
+  return StorageFS::slashify(std::filesystem::temp_directory_path()) + "tiledb_bookkeeping/";
 }
 
 int create_dir(StorageFS *fs, const std::string& dir) {

--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -96,7 +96,9 @@ sleep 5
 run_example ./tiledb_array_read_dense_1 $1 18
 run_example ./tiledb_array_write_sparse_1 $1 19
 sleep 5
+export TILEDB_CACHE=1
 run_example ./tiledb_array_read_sparse_1 $1 20
+unset TILEDB_CACHE
 run_example ./tiledb_array_read_sparse_filter_1 $1 21
 run_example ./tiledb_array_iterator_sparse $1 22
 run_example ./tiledb_array_iterator_sparse_filter $1 23

--- a/examples/src/tiledb_array_read_sparse_1.cc
+++ b/examples/src/tiledb_array_read_sparse_1.cc
@@ -31,8 +31,11 @@
  */
 
 #include "tiledb.h"
+#include "tiledb_utils.h"
 #include <cstdio>
 #include <inttypes.h>
+
+bool is_env_set(const std::string& name);
 
 int main(int argc, char *argv[]) {
   // Initialize context with home dir if specified in command line, else
@@ -42,6 +45,11 @@ int main(int argc, char *argv[]) {
     TileDB_Config tiledb_config;
     tiledb_config.home_ = argv[1];
     tiledb_ctx_init(&tiledb_ctx, &tiledb_config);
+    std::string base_dir(argv[1]);
+    if (base_dir.back() != '/') base_dir += '/';
+    if (std::string(base_dir).find("://") != std::string::npos && is_env_set("TILEDB_CACHE")) {
+      TileDBUtils::cache_fragment_metadata(base_dir+"my_workspace", "sparse_arrays/my_array_B");
+    }
   } else {
     tiledb_ctx_init(&tiledb_ctx, NULL);
   }

--- a/test/src/c_api/test_tiledb_utils.cc
+++ b/test/src/c_api/test_tiledb_utils.cc
@@ -188,7 +188,18 @@ TEST_CASE_METHOD(TempDir, "Test get fragment names", "[get_fragment_names]") {
   // No fragments
   CHECK(TileDBUtils::get_fragment_names(input_ws).size() == 0);
 
-  // TODO: Add input with one fragment
+  // Check caching of bookkeeping files
+  std::string genomicsdb_ws = std::string(TILEDB_TEST_DIR)+"/inputs/genomicsdb_ws";
+  std::string array("1$1$249250621");
+  auto fragment_names = TileDBUtils::get_fragment_names(genomicsdb_ws);
+  CHECK(fragment_names.size() == 1);
+  CHECK(TileDBUtils::cache_fragment_metadata(genomicsdb_ws, array) == TILEDB_OK);
+  auto cached_path = StorageFS::slashify(get_fragment_metadata_cache_dir()) + get_filename_from_path(fragment_names[0]);
+  CHECK(TileDBUtils::is_file(cached_path));
+  auto actual_bk_file = StorageFS::slashify(genomicsdb_ws)+StorageFS::slashify(array)
+      +StorageFS::slashify(fragment_names[0])+TILEDB_BOOK_KEEPING_FILENAME+TILEDB_FILE_SUFFIX+TILEDB_GZIP_SUFFIX;
+  CHECK(TileDBUtils::file_size(cached_path) == TileDBUtils::file_size(actual_bk_file));
+  CHECK(TileDBUtils::delete_file(cached_path) == TILEDB_OK);
 }
 
 TEST_CASE_METHOD(TempDir, "Test multithreaded file utils", "[file_utils_multi_threads]") {


### PR DESCRIPTION
Add cache_fragment_metadata to TileDBUtils to expose this functionality as api.